### PR TITLE
sourceMarkerOptions uses correct styling

### DIFF
--- a/leaflet-arrows.js
+++ b/leaflet-arrows.js
@@ -163,17 +163,19 @@
         this.addLayer(invisibleBackgroundPolyline);
         this.addLayer(polyline);
 
-
-        // that special case, where a circle has to be drawn on the source of the arrow
+        // That special case, where a circle has to be drawn on the source of the arrow.
         if (this.options.drawSourceMarker) {
+          // use the same color as the arrow does
+          this.options.sourceMarkerOptions.fillColor = this.options.color;
           if (typeof this._sourceMarker === 'undefined') {
-            // use the same coloar as the arrow does
-            this.options.sourceMarkerOptions.fillColor = this.color;
             this._sourceMarker = L.circleMarker(this._data.latlng, this.options.sourceMarkerOptions);
           } else {
-            // there is a chance, that the latlng values have been changed by the setData-function
+            // There is a chance that the latlng values have been changed by the setData-function.
             this._sourceMarker.setLatLng(this._data.latlng);
+            // Also the style may have changed before a manual redraw() call.
+            this._sourceMarker.setStyle(this.options.sourceMarkerOptions);
           }
+          this.addLayer(this._sourceMarker);
         }
       }
     },


### PR DESCRIPTION
sourceMarker used to read from the main styling options; change it to use the sourceMarker options.  Also modify logic to redraw in case marker style options changed.